### PR TITLE
Update baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jisc-innovation-mui-components",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "main": "dist/",
     "private": false,
     "engines": {

--- a/src/theme.js
+++ b/src/theme.js
@@ -6,6 +6,16 @@ const breakpoints = createBreakpoints({});
 
 const theme = createMuiTheme({
     overrides: {
+    	MuiCssBaseline: {
+	    '@global': {
+		html: {
+		    height: '100%'
+		},
+		body: {
+		    height: '100%',
+		}
+	    }
+	},
         MuiLink: {
             root: {
                 '&:active': {


### PR DESCRIPTION
Following this tutorial to get the ExploreAI footer always at the bottom of the page:
https://matthewjamestaylor.com/bottom-footer

Needed to update the CSSBaseline in the theme to set the height of the `html` and `body`.