### PR TITLE
Jisc components style bugfix

### DIFF
--- a/src/components/JiscCard/index.jsx
+++ b/src/components/JiscCard/index.jsx
@@ -4,40 +4,35 @@ import { makeStyles, ThemeProvider, Card } from '@material-ui/core';
 
 import jiscTheme from '../../theme.js';
 
-
-
 const useStyles = ({ backgroundColor }) => {
     return makeStyles((theme) => {
         return {
-            root: {
-            },
+            root: {},
             card: {
-                maxWidth: '35vw',
-                },
+                maxWidth: '35vw'
+            },
             style2: {},
             style3: {},
             '@global': {
-
                 // Style 2
                 '[class*="MuiButtonBase"]:focus [class*="MuiCardActionArea-focusHighlight"]': {
                     opacity: '0.8',
-                    border:'4',
+                    border: '4',
                     background: 'transparent',
                     borderColor: '#4BE5B0',
-                    borderStyle: 'solid',
+                    borderStyle: 'solid'
                 },
                 '[class*="style2"]  [class*="MuiCardContent-root"], [class*="style2"] [class*="MuiCardContent-root"] p, [class*="style2"]  [class*="MuiCardActions-root"], [class*="style2"]  [class*="MuiCardActions-root"] button': {
                     backgroundColor: '#37444D',
-                    color: 'white',
+                    color: 'white'
                 },
 
                 // Style 3
                 '[class*="style3"]  [class*="MuiCardContent-root"], [class*="style3"] [class*="MuiCardContent-root"] p, [class*="style3"]  [class*="MuiCardActions-root"], [class*="style3"]  [class*="MuiCardActions-root"] button': {
                     backgroundColor: 'purple',
-                    color: 'white',
-                },
-
-              },
+                    color: 'white'
+                }
+            }
         };
     });
 };
@@ -71,10 +66,10 @@ JiscCard.defaultProps = {
 
 export default (props) => {
     return (
-      <React.Fragment>
-        <ThemeProvider theme={jiscTheme}>
-          <JiscCard {...props} />
-       </ThemeProvider>
-      </React.Fragment>
+        <React.Fragment>
+            <ThemeProvider theme={jiscTheme}>
+                <JiscCard {...props} />
+            </ThemeProvider>
+        </React.Fragment>
     );
-  }
+};

--- a/src/components/JiscCard/index.jsx
+++ b/src/components/JiscCard/index.jsx
@@ -4,60 +4,40 @@ import { makeStyles, ThemeProvider, Card } from '@material-ui/core';
 
 import jiscTheme from '../../theme.js';
 
+
+
 const useStyles = ({ backgroundColor }) => {
     return makeStyles((theme) => {
         return {
             root: {
-                backgroundColor: '#f40'
             },
             card: {
                 maxWidth: '35vw',
-
-                '& :focus': {
-                    '& .MuiCardActionArea-focusHighlight': {
-                        opacity: 0.8,
-                        border: 4,
-                        borderStyle: 'solid',
-                        borderColor: '#4BE5B0',
-                        background: 'transparent'
-                    }
                 },
-                '& .MuiCardActionArea-root': {
-                    opacity: 1
-                }
-            },
-            style2: {
-                '& .MuiCardContent-root': {
+            style2: {},
+            style3: {},
+            '@global': {
+
+                // Style 2
+                '[class*="MuiButtonBase"]:focus [class*="MuiCardActionArea-focusHighlight"]': {
+                    opacity: '0.8',
+                    border:'4',
+                    background: 'transparent',
+                    borderColor: '#4BE5B0',
+                    borderStyle: 'solid',
+                },
+                '[class*="style2"]  [class*="MuiCardContent-root"], [class*="style2"] [class*="MuiCardContent-root"] p, [class*="style2"]  [class*="MuiCardActions-root"], [class*="style2"]  [class*="MuiCardActions-root"] button': {
                     backgroundColor: '#37444D',
                     color: 'white',
-                    '& p': {
-                        color: 'white'
-                    }
                 },
-                '& .MuiCardActions-root': {
-                    backgroundColor: '#445560;',
-                    '& button': {
-                        color: 'white'
-                    }
-                }
-            },
-            style3: {
-                position: 'relative',
-                '& .MuiCardMedia-root': {},
-                '& .MuiCardContent-root': {
+
+                // Style 3
+                '[class*="style3"]  [class*="MuiCardContent-root"], [class*="style3"] [class*="MuiCardContent-root"] p, [class*="style3"]  [class*="MuiCardActions-root"], [class*="style3"]  [class*="MuiCardActions-root"] button': {
                     backgroundColor: 'purple',
                     color: 'white',
-                    '& p': {
-                        color: 'white'
-                    }
                 },
-                '& .MuiCardActions-root': {
-                    backgroundColor: 'purple',
-                    '& button': {
-                        color: 'white'
-                    }
-                }
-            }
+
+              },
         };
     });
 };
@@ -91,8 +71,10 @@ JiscCard.defaultProps = {
 
 export default (props) => {
     return (
+      <React.Fragment>
         <ThemeProvider theme={jiscTheme}>
-            <JiscCard {...props} />
-        </ThemeProvider>
+          <JiscCard {...props} />
+       </ThemeProvider>
+      </React.Fragment>
     );
-};
+  }

--- a/src/theme.js
+++ b/src/theme.js
@@ -14,8 +14,54 @@ const theme = createMuiTheme({
 		body: {
 		    height: '100%',
 		}
-	    }
+	    },
+    
 	},
+    /*
+    card: {
+        root: {
+        maxWidth: '35vw',
+        height: '1000px'
+        }
+    },
+
+    style2: {
+        root: {
+            MuiCardContent: {
+                root: {
+                    backgroundColor: '#37444D',
+                    color: 'white',
+                    '& p': {
+                        color: 'white'
+                    }
+                }
+            },
+            MuiCardActions: {
+                root: {
+                    backgroundColor: '#445560;',
+                    '& button': {
+                        color: 'white'
+                    }
+                }
+            }
+        }
+    },
+
+    MuiButtonBase: {
+        root: {
+            border: 4,
+            borderStyle: 'solid',
+            borderColor: '#fff',
+            '&:focus': {
+                border: 4,
+            borderStyle: 'solid',
+            borderColor: '#4BE5B0',
+            }
+        },
+      },*/
+
+
+
         MuiLink: {
             root: {
                 '&:active': {

--- a/src/theme.js
+++ b/src/theme.js
@@ -15,53 +15,7 @@ const theme = createMuiTheme({
 		    height: '100%',
 		}
 	    },
-    
 	},
-    /*
-    card: {
-        root: {
-        maxWidth: '35vw',
-        height: '1000px'
-        }
-    },
-
-    style2: {
-        root: {
-            MuiCardContent: {
-                root: {
-                    backgroundColor: '#37444D',
-                    color: 'white',
-                    '& p': {
-                        color: 'white'
-                    }
-                }
-            },
-            MuiCardActions: {
-                root: {
-                    backgroundColor: '#445560;',
-                    '& button': {
-                        color: 'white'
-                    }
-                }
-            }
-        }
-    },
-
-    MuiButtonBase: {
-        root: {
-            border: 4,
-            borderStyle: 'solid',
-            borderColor: '#fff',
-            '&:focus': {
-                border: 4,
-            borderStyle: 'solid',
-            borderColor: '#4BE5B0',
-            }
-        },
-      },*/
-
-
-
         MuiLink: {
             root: {
                 '&:active': {


### PR DESCRIPTION
Changed element styles which are specifically targeting Material UI nested components to use [class*="MuiButtonBase"] syntax to enable Explore AI to correctly identify element. Based on the Global CSS override use here:

https://material-ui.com/customization/components/#global-css-override